### PR TITLE
foreign letters support + test

### DIFF
--- a/hebrew_tokenizer/groups.py
+++ b/hebrew_tokenizer/groups.py
@@ -15,6 +15,7 @@ class Groups:
     HEBREW_2 = "HEBREW_2"
     HEBREW = "HEBREW"
     OTHER = "OTHER"
+    FOREIGN = "FOREIGN"
     LINEBREAK = "LINEBREAK"
     BOM = "BOM"
     REPEATED = "REPEATED"
@@ -36,6 +37,7 @@ GroupsReverseMapping = {
     "HEBREW_2": "HEBREW",
     "HEBREW": "HEBREW",
     "OTHER": "OTHER",
+    "FOREIGN": "FOREIGN",
     "LINEBREAK": None,
     "BOM": None,
     "REPEATED": None,

--- a/hebrew_tokenizer/lexicon.py
+++ b/hebrew_tokenizer/lexicon.py
@@ -19,6 +19,7 @@ _punc = r"[,;:\-&!\?\.\]/)'`\"\*\+=_~}\[('`\"{/\\\<\>#%־ ֿֿ]"
 _bad_punc = r"[\'\"]"
 _bom = r"\xef\xbb\xbf|\ufeff|\u200e"
 _other = r"\xa0|\xe2?\x80\xa2?[[^׳-׳×a-zA-Z0-9!\?\.,:;\-()\[\]{}]+"
+_foreign = r"[\w]{1,}[\']?[\"]*[\w|0-9]{1,}|[\w][\w|0-9]*"
 _whitespace = r"\s+"
 _linebreaks = (
     r"{3,}|".join(
@@ -59,6 +60,7 @@ def get_lexicon(python_version_less_than_3=False, python_version_more_than_3_7=F
         lexicon += [(_heb.decode("utf-8"), Groups.HEBREW_1)]
 
     lexicon += [(_heb, Groups.HEBREW_2), (_other, Groups.OTHER)]
+    lexicon += [(_foreign, Groups.FOREIGN)]
 
     if python_version_more_than_3_7:
         lexicon = [(b, a) for a, b in lexicon]

--- a/tests/tokenizer_tests.py
+++ b/tests/tokenizer_tests.py
@@ -118,6 +118,25 @@ def hebrew_and_english(print_results=False):
         "Hebrew and English", sentences, tokenization_ground_truth, print_results
     )
 
+def hebrew_and_foreign(print_results=True):
+    cryllic_MTC = b'\xD0\x9C\xD0\xA2\xD0\xA1'.decode('utf8')
+    cryllic_MTC3 = b'\xD0\x9C\xD0\xA2\xD0\xA13'.decode('utf8')
+    cryllic_M3TC = b'\xD0\x9C3\xD0\xA2\xD0\xA1'.decode('utf8')
+    english_MTC = 'MTC'
+    hebrew_MTC = 'מטח'
+    s1 = f'{cryllic_MTC} {cryllic_MTC3} {cryllic_M3TC}-{english_MTC} {hebrew_MTC}'
+    s1_gt = [
+        (cryllic_MTC, Groups.FOREIGN),
+        (cryllic_MTC3, Groups.FOREIGN),
+        (cryllic_M3TC, Groups.FOREIGN),
+        ('-', Groups.PUNCTUATION),
+        (english_MTC, Groups.ENGLISH),
+        (hebrew_MTC, Groups.HEBREW)
+    ]
+    return compare(
+        "Hebrew and Foreign languages", [s1], [s1_gt], print_results
+    )
+
 
 def hebrew_and_numbers(print_results=False):
     s1 = u'אתמול ב5 אחה"צ, יצאתי עם אמא למכולת'


### PR DESCRIPTION
So, when introducing letters from foreign languages such as Cryllic, the package will return odd results... So, I added a "catch all letters" case after  the English regex rules to check for these options too.
I didn't run the full test, only the new one. But I believe the position of the rule after all the rest makes it safe for use...